### PR TITLE
fix: use internal Nuxt composables for router and runtime config

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,10 +28,10 @@ const plugins = [
 
 // ///////////////////////////////////////////////////////////// registerPlugins
 const registerPlugins = () => {
-    plugins.forEach((plugin) => {
-      addPlugin(plugin)
-      console.log('🔌 [nuxt-module-plausible:plugin]')
-    })
+  plugins.forEach((plugin) => {
+    addPlugin(plugin)
+    console.log('🔌 [nuxt-module-plausible:plugin]')
+  })
 }
 
 // /////////////////////////////////////////////////////////////////////// Setup


### PR DESCRIPTION
`useRouter` and `useRuntimeConfig` are now used in the plugin in order to correctly pull runtime variables such as `siteUrl`